### PR TITLE
minor fixes

### DIFF
--- a/projects/vs2010/dmc_cdll.vcxproj
+++ b/projects/vs2010/dmc_cdll.vcxproj
@@ -187,8 +187,7 @@
       <Command>if not exist "..\..\..\game\mod_dmc\cl_dlls" mkdir "..\..\..\game\mod_dmc\cl_dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>
@@ -219,8 +218,7 @@ copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\cl_dlls\$(TargetNam
       <Command>if not exist "..\..\..\game\mod_dmc\cl_dlls" mkdir "..\..\..\game\mod_dmc\cl_dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\cl_dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>

--- a/projects/vs2010/dmcdll.vcxproj
+++ b/projects/vs2010/dmcdll.vcxproj
@@ -165,8 +165,7 @@
       <Command>if not exist "..\..\..\game\mod_dmc\dlls" mkdir "..\..\..\game\mod_dmc\dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_dmc\dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_dmc\dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>
@@ -195,8 +194,7 @@ copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\dlls\$(TargetName).
       <Command>if not exist "..\..\..\game\mod_dmc\dlls" mkdir "..\..\..\game\mod_dmc\dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_dmc\dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_dmc\dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_dmc\dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>

--- a/projects/vs2010/hl_cdll.vcxproj
+++ b/projects/vs2010/hl_cdll.vcxproj
@@ -71,8 +71,7 @@
       <Command>if not exist "..\..\..\game\mod_hl\cl_dlls" mkdir "..\..\..\game\mod_hl\cl_dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>
@@ -104,8 +103,7 @@ copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\cl_dlls\$(TargetName
       <Command>if not exist "..\..\..\game\mod_hl\cl_dlls" mkdir "..\..\..\game\mod_hl\cl_dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\cl_dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>

--- a/projects/vs2010/hldll.vcxproj
+++ b/projects/vs2010/hldll.vcxproj
@@ -69,8 +69,7 @@
       <Command>if not exist "..\..\..\game\mod_hl\dlls" mkdir "..\..\..\game\mod_hl\dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_hl\dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_hl\dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>
@@ -100,8 +99,7 @@ copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\dlls\$(TargetName).p
       <Command>if not exist "..\..\..\game\mod_hl\dlls" mkdir "..\..\..\game\mod_hl\dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_hl\dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_hl\dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_hl\dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>

--- a/projects/vs2010/ricochet_cdll.vcxproj
+++ b/projects/vs2010/ricochet_cdll.vcxproj
@@ -179,8 +179,7 @@
       <Command>if not exist "..\..\..\game\mod_ricochet\cl_dlls" mkdir "..\..\..\game\mod_ricochet\cl_dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>
@@ -211,8 +210,7 @@ copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\cl_dlls\$(Targ
       <Command>if not exist "..\..\..\game\mod_ricochet\cl_dlls" mkdir "..\..\..\game\mod_ricochet\cl_dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\cl_dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>

--- a/projects/vs2010/ricochetdll.vcxproj
+++ b/projects/vs2010/ricochetdll.vcxproj
@@ -168,8 +168,7 @@
       <Command>if not exist "..\..\..\game\mod_ricochet\dlls" mkdir "..\..\..\game\mod_ricochet\dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_ricochet\dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_ricochet\dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>
@@ -198,8 +197,7 @@ copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\dlls\$(TargetN
       <Command>if not exist "..\..\..\game\mod_ricochet\dlls" mkdir "..\..\..\game\mod_ricochet\dlls"
 call "..\..\filecopy.bat" "$(TargetPath)" "..\..\..\game\mod_ricochet\dlls\$(TargetName).dll"
 call "..\..\filecopy.bat" "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\dlls\$(TargetName).pdb"
-copy "$(TargetPath)" "..\..\..\game\mod_ricochet\dlls\$(TargetName).dll"
-copy "$(TargetDir)\$(TargetName).pdb" "..\..\..\game\mod_ricochet\dlls\$(TargetName).pdb"</Command>
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing Post-Build Event</Message>

--- a/utils/qrad/qrad.c
+++ b/utils/qrad/qrad.c
@@ -1086,8 +1086,8 @@ readtransfers(char *transferfile, long numpatches)
 {
 	int		handle;
 	long	readpatches = 0, readtransfers = 0, totalbytes = 0;
-	long	start, end;
-	Q_time((time_t*)&start);
+	time_t	start, end;
+	Q_time(&start);
 	if ( (handle = _open( transferfile, _O_RDONLY | _O_BINARY )) != -1 )
 	{
 		long			filepatches;
@@ -1147,7 +1147,7 @@ readtransfers(char *transferfile, long numpatches)
 				Q_printf("\nIncorrect transfer patch count found!  Save file will now be rebuilt." );
 		}
 		_close( handle );
-		Q_time((time_t*)&end);
+		Q_time(&end);
 		Q_printf("%10.3fMB] (%d)\n",totalbytes/(1024.0*1024.0), end-start);
 	}
 

--- a/utils/qrad/vismat.c
+++ b/utils/qrad/vismat.c
@@ -290,8 +290,8 @@ getfiledata(char *filename, char *buffer, int buffersize)
 {
 	long			size = 0;
 	int				handle;
-	long			start,end;
-	Q_time((time_t*)&start);
+	time_t			start,end;
+	Q_time(&start);
 
 	if ( (handle = _open( filename, _O_RDONLY | _O_BINARY )) != -1 )
 	{
@@ -303,7 +303,7 @@ getfiledata(char *filename, char *buffer, int buffersize)
 			buffer += bytesread;
 		}
 		_close( handle );
-		Q_time((time_t*)&end);
+		Q_time(&end);
 		Q_printf("%10.3fMB] (%d)\n",size/(1024.0*1024.0), end-start);
 	}
 

--- a/utils/serverctrl/ServerCtrlDlg.cpp
+++ b/utils/serverctrl/ServerCtrlDlg.cpp
@@ -1,9 +1,10 @@
 // ServerCtrlDlg.cpp : implementation file
 //
 
+#include "stdafx.h"
+
 #include "../../public/vstdlib/warnings.h"
 
-#include "stdafx.h"
 #include <afxpriv.h>
 #include <mmsystem.h>
 #include "ServerCtrl.h"


### PR DESCRIPTION
- projects in projects.sln: filecopy already does the work, even if there
  is a message about the missing p4 command
- fixed type problems for a few Q_time calls (could become a memory access
  problem if time_t is not equal to long)
- made stdafx.h first include in ServerCtrlDlg.cpp again, stfadx.h
  (Precompiled header) has to be the first include always (Please note
  that it will even skip any comments prior to that include when using
  PCH, but those were originally there, so I left them like that)
