### PR TITLE
Added option to fire specified target when hev and health charger are empty

### DIFF
--- a/tot/dlls/h_battery.cpp
+++ b/tot/dlls/h_battery.cpp
@@ -47,6 +47,7 @@ public:
 	int		m_iJuice;
 	int		m_iOn;			// 0 = off, 1 = startup, 2 = going
 	float   m_flSoundTime;
+	BOOL	m_bTriggerable;
 };
 
 TYPEDESCRIPTION CRecharge::m_SaveData[] =
@@ -56,6 +57,7 @@ TYPEDESCRIPTION CRecharge::m_SaveData[] =
 	DEFINE_FIELD( CRecharge, m_iJuice, FIELD_INTEGER),
 	DEFINE_FIELD( CRecharge, m_iOn, FIELD_INTEGER),
 	DEFINE_FIELD( CRecharge, m_flSoundTime, FIELD_TIME ),
+	DEFINE_FIELD(CRecharge, m_bTriggerable, FIELD_BOOLEAN)
 };
 
 IMPLEMENT_SAVERESTORE( CRecharge, CBaseEntity );
@@ -93,7 +95,8 @@ void CRecharge::Spawn()
 	UTIL_SetSize(pev, pev->mins, pev->maxs);
 	SET_MODEL(ENT(pev), STRING(pev->model) );
 	m_iJuice = gSkillData.suitchargerCapacity;
-	pev->frame = 0;			
+	m_bTriggerable = TRUE;
+	pev->frame = 0;
 }
 
 void CRecharge::Precache()
@@ -113,7 +116,11 @@ void CRecharge::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE use
 	// if there is no juice left, turn it off
 	if (m_iJuice <= 0)
 	{
-		pev->frame = 1;			
+		pev->frame = 1;
+		if (m_bTriggerable) {
+			FireTargets(STRING(pev->target), pActivator, this, USE_TOGGLE, 0);
+			m_bTriggerable = FALSE;
+		}
 		Off();
 	}
 
@@ -178,8 +185,9 @@ void CRecharge::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE use
 void CRecharge::Recharge(void)
 {
 	m_iJuice = gSkillData.suitchargerCapacity;
-	pev->frame = 0;			
-	SetThink( &CRecharge::SUB_DoNothing );
+	m_bTriggerable = TRUE;
+	pev->frame = 0;
+	SetThink(&CRecharge::SUB_DoNothing);
 }
 
 void CRecharge::Off(void)

--- a/tot/dlls/h_battery.cpp
+++ b/tot/dlls/h_battery.cpp
@@ -47,7 +47,9 @@ public:
 	int		m_iJuice;
 	int		m_iOn;			// 0 = off, 1 = startup, 2 = going
 	float   m_flSoundTime;
+#if defined ( TOT_DLL )
 	BOOL	m_bTriggerable;
+#endif
 };
 
 TYPEDESCRIPTION CRecharge::m_SaveData[] =
@@ -57,7 +59,9 @@ TYPEDESCRIPTION CRecharge::m_SaveData[] =
 	DEFINE_FIELD( CRecharge, m_iJuice, FIELD_INTEGER),
 	DEFINE_FIELD( CRecharge, m_iOn, FIELD_INTEGER),
 	DEFINE_FIELD( CRecharge, m_flSoundTime, FIELD_TIME ),
-	DEFINE_FIELD(CRecharge, m_bTriggerable, FIELD_BOOLEAN)
+#if defined ( TOT_DLL )
+	DEFINE_FIELD(CRecharge, m_bTriggerable, FIELD_BOOLEAN),
+#endif
 };
 
 IMPLEMENT_SAVERESTORE( CRecharge, CBaseEntity );
@@ -95,8 +99,10 @@ void CRecharge::Spawn()
 	UTIL_SetSize(pev, pev->mins, pev->maxs);
 	SET_MODEL(ENT(pev), STRING(pev->model) );
 	m_iJuice = gSkillData.suitchargerCapacity;
-	m_bTriggerable = TRUE;
-	pev->frame = 0;
+	pev->frame = 0;		
+#if defined ( TOT_DLL )
+	m_bTriggerable = !FStringNull(pev->target);
+#endif
 }
 
 void CRecharge::Precache()
@@ -117,10 +123,12 @@ void CRecharge::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE use
 	if (m_iJuice <= 0)
 	{
 		pev->frame = 1;
+#if defined ( TOT_DLL )
 		if (m_bTriggerable) {
 			FireTargets(STRING(pev->target), pActivator, this, USE_TOGGLE, 0);
 			m_bTriggerable = FALSE;
 		}
+#endif
 		Off();
 	}
 
@@ -185,9 +193,11 @@ void CRecharge::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE use
 void CRecharge::Recharge(void)
 {
 	m_iJuice = gSkillData.suitchargerCapacity;
-	m_bTriggerable = TRUE;
-	pev->frame = 0;
-	SetThink(&CRecharge::SUB_DoNothing);
+#if defined ( TOT_DLL )
+	m_bTriggerable = !FStringNull(pev->target);
+#endif
+	pev->frame = 0;			
+	SetThink( &CRecharge::SUB_DoNothing );
 }
 
 void CRecharge::Off(void)


### PR DESCRIPTION
Hi,

I'm the original creator of the mod "Times of Troubles". I didn't write the code back then but I compared the code of your github repo to the backup I had and two very subtle changes were missing: Both the HEV and health chargers (wall-mounted) were given the option to fire a specified target as soon as they're empty. 
This is being used for a) a small light that indicates the charger is empty and b) for scary effects like appearing monsters as soon as the charger is empty.

Please consider merging this into the branch mod-hl-tot. 